### PR TITLE
Use exceptions .ToString() when printing error

### DIFF
--- a/src/Fornax/Fornax.fs
+++ b/src/Fornax/Fornax.fs
@@ -165,7 +165,7 @@ let main argv =
                 | FornaxGeneratorException message ->
                     printfn "%s%s%s" message Environment.NewLine waitingForChangesMessage
                 | exn ->
-                    printfn "An unexpected error happend: %s%s%s" exn.Message Environment.NewLine exn.StackTrace
+                    printfn "An unexpected error happend: %O" exn
                     exit 1
 
             guardedGenerate ()


### PR DESCRIPTION
I believe this to better as all inner exceptions will also be printed. I found myself in a position where I was only getting a message about TargetInvocationException being thrown