### PR TITLE
Allow generate to return a byte array

### DIFF
--- a/src/Fornax.Template/generators/staticfile.fsx
+++ b/src/Fornax.Template/generators/staticfile.fsx
@@ -4,4 +4,4 @@ open System.IO
 
 let generate (ctx : SiteContents) (projectRoot: string) (page: string) =
     let inputPath = Path.Combine(projectRoot, page)
-    File.ReadAllText inputPath
+    File.ReadAllBytes inputPath  


### PR DESCRIPTION
I ran into an issue on Windows where a byte order marker was being inserted by File.WriteAllBytes which corrupted the images when copied to the _public directory. This change allows a generate function to either return a string or a byte array, allowing a user to choose to generate a binary file.