### PR TITLE
Summarize posts using more marker

### DIFF
--- a/src/Fornax.Template/generators/index.fsx
+++ b/src/Fornax.Template/generators/index.fsx
@@ -15,7 +15,7 @@ let generate' (ctx : SiteContents) (_: string) =
     posts
     |> Seq.sortByDescending Layout.published
     |> Seq.toList
-    |> List.map Layout.postLayout
+    |> List.map (Layout.postLayout true)
 
   Layout.layout ctx "Home" [
     section [Class "hero is-info is-medium is-bold"] [

--- a/src/Fornax.Template/generators/layout.fsx
+++ b/src/Fornax.Template/generators/layout.fsx
@@ -88,7 +88,7 @@ let published (post: Postloader.Post) =
     |> Option.defaultValue System.DateTime.Now
     |> fun n -> n.ToString("yyyy-MM-dd")
 
-let postLayout (post: Postloader.Post) =
+let postLayout (useSummary: bool) (post: Postloader.Post) =
     div [Class "card article"] [
         div [Class "card-content"] [
             div [Class "media-content has-text-centered"] [
@@ -99,7 +99,8 @@ let postLayout (post: Postloader.Post) =
                 ]
             ]
             div [Class "content article-body"] [
-                !! post.content
+                !! (if useSummary then post.summary else post.content)
+
             ]
         ]
     ]

--- a/src/Fornax.Template/generators/post.fsx
+++ b/src/Fornax.Template/generators/post.fsx
@@ -27,7 +27,7 @@ let generate' (ctx : SiteContents) (page: string) =
         div [Class "container"] [
             section [Class "articles"] [
                 div [Class "column is-8 is-offset-2"] [
-                    Layout.postLayout post
+                    Layout.postLayout false post
                 ]
             ]
         ]

--- a/src/Fornax.Template/posts/post.md
+++ b/src/Fornax.Template/posts/post.md
@@ -8,6 +8,8 @@ published: 2020-02-19
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nisi diam, vehicula quis blandit id, suscipit sed libero. Proin at diam dolor. In hac habitasse platea dictumst. Donec quis dui vitae quam eleifend dignissim non sed libero. In hac habitasse platea dictumst. In ullamcorper mollis risus, a vulputate quam accumsan at. Donec sed felis sodales, blandit orci id, vulputate orci.
 
+<!--more-->
+
 Phasellus aliquam tellus eu augue vulputate laoreet. Nunc tincidunt sed mauris eu vestibulum. Quisque id ex eget erat elementum euismod vel nec ex. Nunc et blandit neque. Duis erat ex, facilisis non consectetur sit amet, consectetur mattis ex. Vestibulum quis ligula pharetra, semper nibh nec, porta augue. In placerat auctor risus, eu dictum purus iaculis et. Vivamus viverra sollicitudin augue, in sollicitudin leo malesuada non.
 
 In hac habitasse platea dictumst. Quisque a diam egestas, ornare felis quis, gravida arcu. In vel tellus facilisis, rhoncus ligula sit amet, feugiat massa. Interdum et malesuada fames ac ante ipsum primis in faucibus. Curabitur varius interdum dolor, ut pretium augue egestas id. Aenean vulputate commodo nibh tristique egestas. Interdum et malesuada fames ac ante ipsum primis in faucibus. Vivamus elementum non mi sit amet lacinia.

--- a/src/Fornax.Template/posts/post2.md
+++ b/src/Fornax.Template/posts/post2.md
@@ -8,6 +8,8 @@ published: 2020-02-20
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nisi diam, vehicula quis blandit id, suscipit sed libero. Proin at diam dolor. In hac habitasse platea dictumst. Donec quis dui vitae quam eleifend dignissim non sed libero. In hac habitasse platea dictumst. In ullamcorper mollis risus, a vulputate quam accumsan at. Donec sed felis sodales, blandit orci id, vulputate orci.
 
+<!--more-->
+
 In est nulla, ornare vitae elit sed, consequat sollicitudin dui. Duis posuere nulla malesuada elit volutpat ultricies. Mauris et tellus tortor. In ligula elit, pellentesque eget est et, mattis rhoncus nisl. Sed orci ex, mollis quis justo eu, dapibus tincidunt turpis. Sed rhoncus odio non lacus ullamcorper volutpat. Suspendisse blandit ullamcorper condimentum. Quisque et viverra nisi. Vivamus in mollis nulla. Nulla faucibus sed ligula et blandit.
 
 Vivamus nec libero faucibus, cursus ex et, consequat mauris. Pellentesque commodo ullamcorper vestibulum. Donec efficitur, ipsum et dapibus varius, purus mauris gravida augue, eu mattis lorem turpis eget dui. Curabitur nibh erat, posuere sed eros a, blandit venenatis risus. Vestibulum cursus imperdiet ultrices. In eu efficitur dui, eget tempus enim. Nunc imperdiet, enim et sagittis lacinia, lacus metus eleifend purus, blandit pellentesque leo ante ac velit. Nam ac sagittis est. Cras accumsan, odio vel lacinia mollis, metus tortor malesuada nisi, et consectetur neque quam in erat. Sed ultricies aliquam hendrerit. Etiam non aliquam ipsum, id rutrum magna. Morbi id tincidunt mauris. Vestibulum nec iaculis massa. Etiam fringilla, orci quis faucibus vulputate, risus nibh finibus nisl, et vehicula ipsum leo a tortor. Curabitur mauris elit, bibendum vitae velit at, dignissim ornare arcu.


### PR DESCRIPTION
Feature that is available in hugo, allows you to post a summary of a post on the index page, requiring the user to click though to read the full article.