### PR TITLE
Trim file paths with a platform-agnostic path separator

### DIFF
--- a/src/Fornax.Template/loaders/postloader.fsx
+++ b/src/Fornax.Template/loaders/postloader.fsx
@@ -85,7 +85,7 @@ let loadFile (rootDir: string) (n: string) =
     let summary, content = getContent text
 
     let chopLength =
-        if rootDir.EndsWith("\\") then rootDir.Length
+        if rootDir.EndsWith(Path.DirectorySeparatorChar) then rootDir.Length
         else rootDir.Length + 1
 
     let dirPart =


### PR DESCRIPTION
There is platform-dependent logic in how the `loaders/postloader.fsx` script determines the character length of file paths:

https://github.com/ionide/Fornax/blob/5902c57f42ced02d9c825bb7a6a41543499cc88a/src/Fornax.Template/loaders/postloader.fsx#L87-L89

On Unix-based platforms, the `else` branch is always executed, resulting in truncated paths like `osts/post.md`. When this gets passed to the `generators/post.fsx` script, `Seq.find` throws an unhandled `KeyNotFoundException`:

<details>
<summary>
    BROKEN: `dotnet fake build -t TestTemplate` | OS: (Debian) 10.5 | RID: linux-x64
</summary>
<pre>
Starting target 'TestTemplate'
templateDir: /home/rob/dev/Fornax/src/Fornax.Template/
/home/rob/dev/Fornax/src/Fornax.Template/> "dotnet" /home/rob/dev/Fornax/temp/Fornax.dll watch (In: false, Out: false, Err: false)
[19:20:24] multiple files generated in 530ms
[19:20:25] '/home/rob/dev/Fornax/src/Fornax.Template/_public/about.html' generated in 682ms
[19:20:25] '/home/rob/dev/Fornax/src/Fornax.Template/_public/contact.html' generated in 678ms
[../post.fsx,12] Does osts/post6.md match posts/post6.md ?
[../post.fsx,12] Does osts/post.md match posts/post6.md ?
[../post.fsx,12] Does osts/post2.md match posts/post6.md ?
[../post.fsx,12] Does osts/post4.md match posts/post6.md ?
[../post.fsx,12] Does osts/post5.md match posts/post6.md ?
[../post.fsx,12] Does osts/post3.md match posts/post6.md ?
[../post.fsx,12] Does osts/subdir/post3.md match posts/post6.md ?
An unexpected error happend: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.Collections.Generic.KeyNotFoundException: An index satisfying the predicate was not found in the collection.
   at Microsoft.FSharp.Collections.SeqModule.Find[T](FSharpFunc`2 predicate, IEnumerable`1 source) in F:\workspace\_work\1\s\src\fsharp\FSharp.Core\seq.fs:line 677
   at FSI_0022.Post.generate'(SiteContents ctx, String page)
   at lambda_method21(Closure , Unit , SiteContents , String , String )
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at Generator.EvaluatorHelpers.helper@56(Object next, FSharpList`1 args) in /home/rob/dev/Fornax/src/Fornax/Generator.fs:line 66
   at Generator.EvaluatorHelpers.invokeFunction(Object f, IEnumerable`1 args) in /home/rob/dev/Fornax/src/Fornax/Generator.fs:line 70
   at Generator.GeneratorEvaluator.evaluate@194-1.Invoke(Object generator) in /home/rob/dev/Fornax/src/Fornax/Generator.fs:line 195
   at System.Runtime.CompilerServices.RuntimeHelpers.DispatchTailCalls(IntPtr callersRetAddrSlot, IntPtr callTarget, IntPtr retVal)
   at Generator.GeneratorEvaluator.evaluate(FsiEvaluationSession fsi, SiteContents siteContent, String generatorPath, String projectRoot, String page) in /home/rob/dev/Fornax/src/Fornax/Generator.fs:line 190
   at Generator.generate(FsiEvaluationSession fsi, Config cfg, SiteContents siteContent, String projectRoot, String page) in /home/rob/dev/Fornax/src/Fornax/Generator.fs:line 333
   at Generator.action@1-3(String projectRoot, FsiEvaluationSession fsi, Config config, SiteContents sc, String filePath) in /home/rob/dev/Fornax/src/Fornax/Generator.fs:line 496
   at Generator.generateFolder(String projectRoot, Boolean isWatch) in /home/rob/dev/Fornax/src/Fornax/Generator.fs:line 495
   at Fornax.guardedGenerate@226(String cwd, Unit unitVar0) in /home/rob/dev/Fornax/src/Fornax/Fornax.fs:line 228
Finished (Failed) 'TestTemplate' in 00:00:24.6853931
</pre>
</details>

<details>
<summary>
    PATCHED: `dotnet fake build -t TestTemplate` | OS: (Debian) 10.5 | RID: linux-x64
</summary>
<pre>
Starting target 'TestTemplate'
templateDir: /home/rob/dev/Fornax/src/Fornax.Template/
/home/rob/dev/Fornax/src/Fornax.Template/> "dotnet" /home/rob/dev/Fornax/temp/Fornax.dll watch (In: false, Out: false, Err: false)
[19:28:28] multiple files generated in 605ms
[19:28:29] '/home/rob/dev/Fornax/src/Fornax.Template/_public/about.html' generated in 781ms
[19:28:30] '/home/rob/dev/Fornax/src/Fornax.Template/_public/contact.html' generated in 722ms
[../post.fsx,12] Does posts/post6.md match posts/post6.md ?
[19:28:31] '/home/rob/dev/Fornax/src/Fornax.Template/_public/posts/post6.html' generated in 909ms
[../post.fsx,12] Does posts/post6.md match posts/post.md ?
[../post.fsx,12] Does posts/post.md match posts/post.md ?
[19:28:31] '/home/rob/dev/Fornax/src/Fornax.Template/_public/posts/post.html' generated in 3ms
[../post.fsx,12] Does posts/post6.md match posts/post2.md ?
[../post.fsx,12] Does posts/post.md match posts/post2.md ?
[../post.fsx,12] Does posts/post2.md match posts/post2.md ?
[19:28:31] '/home/rob/dev/Fornax/src/Fornax.Template/_public/posts/post2.html' generated in 3ms
[../post.fsx,12] Does posts/post6.md match posts/post4.md ?
[../post.fsx,12] Does posts/post.md match posts/post4.md ?
[../post.fsx,12] Does posts/post2.md match posts/post4.md ?
[../post.fsx,12] Does posts/post4.md match posts/post4.md ?
[19:28:31] '/home/rob/dev/Fornax/src/Fornax.Template/_public/posts/post4.html' generated in 3ms
[../post.fsx,12] Does posts/post6.md match posts/post5.md ?
[../post.fsx,12] Does posts/post.md match posts/post5.md ?
[../post.fsx,12] Does posts/post2.md match posts/post5.md ?
[../post.fsx,12] Does posts/post4.md match posts/post5.md ?
[../post.fsx,12] Does posts/post5.md match posts/post5.md ?
[19:28:31] '/home/rob/dev/Fornax/src/Fornax.Template/_public/posts/post5.html' generated in 4ms
[../post.fsx,12] Does posts/post6.md match posts/post3.md ?
[../post.fsx,12] Does posts/post.md match posts/post3.md ?
[../post.fsx,12] Does posts/post2.md match posts/post3.md ?
[../post.fsx,12] Does posts/post4.md match posts/post3.md ?
[../post.fsx,12] Does posts/post5.md match posts/post3.md ?
[../post.fsx,12] Does posts/post3.md match posts/post3.md ?
[19:28:31] '/home/rob/dev/Fornax/src/Fornax.Template/_public/posts/post3.html' generated in 4ms
[19:28:31] '/home/rob/dev/Fornax/src/Fornax.Template/_public/js/sampleJsFile.js' generated in 141ms
[19:28:31] '/home/rob/dev/Fornax/src/Fornax.Template/_public/images/avatar.jpg' generated in 1ms
[19:28:31] '/home/rob/dev/Fornax/src/Fornax.Template/_public/images/bulma.png' generated in 1ms
[19:28:31] '/home/rob/dev/Fornax/src/Fornax.Template/_public/images/favicon.png' generated in 1ms
[19:28:31] '/home/rob/dev/Fornax/src/Fornax.Template/_public/style/style.css' generated in 1ms
[../post.fsx,12] Does posts/post6.md match posts/subdir/post3.md ?
[../post.fsx,12] Does posts/post.md match posts/subdir/post3.md ?
[../post.fsx,12] Does posts/post2.md match posts/subdir/post3.md ?
[../post.fsx,12] Does posts/post4.md match posts/subdir/post3.md ?
[../post.fsx,12] Does posts/post5.md match posts/subdir/post3.md ?
[../post.fsx,12] Does posts/post3.md match posts/subdir/post3.md ?
[../post.fsx,12] Does posts/subdir/post3.md match posts/subdir/post3.md ?
[19:28:31] '/home/rob/dev/Fornax/src/Fornax.Template/_public/posts/subdir/post3.html' generated in 4ms
Generation time: 00:00:23.4658193
[19:28:31] Watch mode started. Press any key to exit.
[19:28:31 INF] Smooth! Suave listener started in 143.693ms with binding 127.0.0.1:8080
</pre>
</details>

This partly addresses the issue reported at #84.