### PR TITLE
Fix #63: Support file with spaces in the name

### DIFF
--- a/src/Fornax/Generator.fs
+++ b/src/Fornax/Generator.fs
@@ -445,7 +445,8 @@ let generateFolder (sc : SiteContents) (projectRoot : string) (isWatch: bool) =
     let relative toPath fromPath =
         let toUri = Uri(toPath)
         let fromUri = Uri(fromPath)
-        toUri.MakeRelativeUri(fromUri).OriginalString
+        let relativeUri = toUri.MakeRelativeUri(fromUri).OriginalString
+        Uri.UnescapeDataString(relativeUri)
 
     let projectRoot =
         if projectRoot.EndsWith (string Path.DirectorySeparatorChar) then projectRoot


### PR DESCRIPTION
I tested this changes by adding a file `posts/a post with spaces.md` in my project and it seems to be working for me.