### PR TITLE
Add colors to error/success/info messages

### DIFF
--- a/src/Fornax/Fornax.fsproj
+++ b/src/Fornax/Fornax.fsproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\Fornax.Core\Fornax.Core.fsproj" />
 
     <Compile Include="FSIRefs.fs" />
+    <Compile Include="Logger.fs" />
     <Compile Include="Generator.fs" />
     <Compile Include="Fornax.fs" />
     <!-- we want the include the raw template files

--- a/src/Fornax/Logger.fs
+++ b/src/Fornax/Logger.fs
@@ -1,0 +1,14 @@
+module Logger
+
+open System
+
+let consoleColor (fc : ConsoleColor) =
+    let current = Console.ForegroundColor
+    Console.ForegroundColor <- fc
+    { new IDisposable with
+            member x.Dispose() = Console.ForegroundColor <- current }
+
+let stringFormatter str = Printf.StringFormat<_, unit>(str) 
+let informationfn str = Printf.kprintf (fun s -> use c = consoleColor ConsoleColor.Cyan in printfn "%s" s) str
+let errorfn str = Printf.kprintf (fun s -> use c = consoleColor ConsoleColor.Red in printfn "%s" s) str
+let okfn str = Printf.kprintf (fun s -> use c = consoleColor ConsoleColor.Green in printfn "%s" s) str


### PR DESCRIPTION
Per #114
Move Logger to it's own module and make log out text with different color values.
Also change the way `fornax clean` works in terms of success/error.