### PR TITLE
Update the upload-artifact CI action to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
     - name: Build
       run: dotnet run
     - name: Upload a Build Artifact
-      uses: actions/upload-artifact@v2.3.1
+      uses: actions/upload-artifact@v4
       with:
+        name: fornax-artifacts-${{ matrix.os }}
         path: out


### PR DESCRIPTION
refs the build failure in https://github.com/ionide/Fornax/actions/runs/16129383172