### PR TITLE
Allow Fornax.Core to use FSharp.Core 6.0.7 or newer

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <RestorePackagesWithLockFile>false</RestorePackagesWithLockFile>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <!-- Fornax.Core doesn't use FCS, so we don't need to pin FSharp.Core to a matching version -->
+    <FornaxCoreFSharpCoreVersion>6.0.7</FornaxCoreFSharpCoreVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="FSharp.Core" Version="[8.0.100]" />

--- a/src/Fornax.Core/Fornax.Core.fsproj
+++ b/src/Fornax.Core/Fornax.Core.fsproj
@@ -9,6 +9,6 @@
     <Compile Include="Model.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" />
+    <PackageReference Include="FSharp.Core" VersionOverride="$(FornaxCoreFSharpCoreVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
instead of pinning it to the version needed by the FCS build used in the CLI tool

refs https://github.com/ionide/Fornax/issues/128

When I replaced Paket with NuGet central package management, it made everything use the version of FSharp.Core needed by the version of FCS used by the CLI tool.
However - Fornax.Core doesn't use FCS so it could be more flexible there. 6.0.7 is just what it was using before the Paket changes, there was no other reason to pick that version in particular.