### PR TITLE
Update Ionide.KeepAChangelog.Tasks to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,102 +1,102 @@
 # Changelog
 
-## 0.16.0-beta002 - 08.07.2025
+## [0.16.0-beta002] - 2025-07-08
 
 ### Changed
-* [Update to .NET 8](https://github.com/ionide/Fornax/pull/127) (thanks @Numpsy!)
+- [Update to .NET 8](https://github.com/ionide/Fornax/pull/127) (thanks @Numpsy!)
 
-## 0.15.1 - 07.03.2023
+## [0.15.1] - 2023-03-07
 
 ### Fixed
-* [Support file with spaces in the name](https://github.com/ionide/Fornax/pull/116) (thanks @MangelMaxime!)
+- [Support file with spaces in the name](https://github.com/ionide/Fornax/pull/116) (thanks @MangelMaxime!)
 
 ### Changed
-* [Add colors to error/success/info messages](https://github.com/ionide/Fornax/pull/118) (thanks @drewknab!)
-* [Update to .NET 6, use project-based FAKE build instead of script](https://github.com/ionide/Fornax/pull/122) (thanks @kMutagene!)
+- [Add colors to error/success/info messages](https://github.com/ionide/Fornax/pull/118) (thanks @drewknab!)
+- [Update to .NET 6, use project-based FAKE build instead of script](https://github.com/ionide/Fornax/pull/122) (thanks @kMutagene!)
 
-## 0.14.3 - 07.05.2022
+## [0.14.3] - 2022-05-07
 
 ### Fixed
 
-* [improved support for watch mode](https://github.com/ionide/Fornax/pull/103) (thanks @bigjonroberts!)
+- [improved support for watch mode](https://github.com/ionide/Fornax/pull/103) (thanks @bigjonroberts!)
 
-## 0.14.1 - 29.04.2022
-
-### Added
-
-* [A new case for the `HtmlElement` type was added for custom tags](https://github.com/ionide/Fornax/pull/106) (thanks @Freymaurer!)
-
-## 0.14.0 - 15.01.2022
+## [0.14.1] - 2022-04-29
 
 ### Added
 
-* Update to FCS 41
-* Add Sourcelink to the core library
-* Support .NET 5 and .NET 6
-* typo fix for the About page
-* Trim file paths with a platform-agnostic path separator (#91)
-* Add some Generator documentation.
-* Minor readme grammatical fixes (#83)
-* Misc fixes (#80)
-* Watch mode enhancement (#79)
-* Update to .NET 5 (#78)
-* Change after testing on Windows Directory.Delete throws exception on files with read-only attribute.
-* Add LibGit2Sharp, add sub commands to fornax new
-* Update FCS, fake-cli and paket. (#73)
-* Add GitHub Actions build (#74)
-* Improve mobile layout
-* allow the user to configure pages size in the global loader
-* Add support for paging
-* Improve perf by caching generators (#65)
-* Default template does not support on sub-dirs (#64)
-* fix typo (#62)
+- [A new case for the `HtmlElement` type was added for custom tags](https://github.com/ionide/Fornax/pull/106) (thanks @Freymaurer!)
 
-## 0.13.1 - 24.04.2020
+## [0.14.0] - 2022-01-15
 
 ### Added
-* Update to FCS 35.0 (by [@Krzysztof-Cieslak](https://github.com/Krzysztof-Cieslak))
-* Pass `WATCH` define in case of watch mode (by [@Krzysztof-Cieslak](https://github.com/Krzysztof-Cieslak))
 
-## 0.13.0 - 20.04.2020
-### Added
-* Add way to check developments to the template (by [@robertpi](https://github.com/robertpi))
-* Summarize posts using more marker (by [@robertpi](https://github.com/robertpi))
-* Update to FCS 34.1 (by [@Krzysztof-Cieslak](https://github.com/Krzysztof-Cieslak))
+- Update to FCS 41
+- Add Sourcelink to the core library
+- Support .NET 5 and .NET 6
+- typo fix for the About page
+- [Trim file paths with a platform-agnostic path separator](https://github.com/ionide/Fornax/pull/91)
+- Add some Generator documentation.
+- [Minor readme grammatical fixes](https://github.com/ionide/Fornax/pull/83)
+- [Misc fixes](https://github.com/ionide/Fornax/pull/80)
+- [Watch mode enhancement](https://github.com/ionide/Fornax/pull/79)
+- [Update to .NET 5](https://github.com/ionide/Fornax/pull/78)
+- Change after testing on Windows Directory.Delete throws exception on files with read-only attribute.
+- Add LibGit2Sharp, add sub commands to fornax new
+- [Update FCS, fake-cli and paket.](https://github.com/ionide/Fornax/pull/73)
+- [Add GitHub Actions build](https://github.com/ionide/Fornax/pull/74)
+- Improve mobile layout
+- allow the user to configure pages size in the global loader
+- Add support for paging
+- [Improve perf by caching generators](https://github.com/ionide/Fornax/pull/65)
+- [Default template does not support on sub-dirs](https://github.com/ionide/Fornax/pull/64)
+- [fix typo](https://github.com/ionide/Fornax/pull/62)
 
-## 0.12.0 - 14.04.2020
-### Added
-* WebSocket refresh uses excesive CPU (by [@robertpi](https://github.com/robertpi))
-* Allow generate to return a byte array (by [@robertpi](https://github.com/robertpi))
-* Refactor template (by [@robertpi](https://github.com/robertpi))
+## [0.13.1] - 2020-04-24
 
-## 0.11.1 - 07.04.2020
 ### Added
-* Fix for once generator running even if not found (by [@sasmithjr](https://github.com/sasmithjr))
-* Use exceptions .ToString() when printing error (by [@robertpi](https://github.com/robertpi))
+- Update to FCS 35.0 (by [@Krzysztof-Cieslak](https://github.com/Krzysztof-Cieslak))
+- Pass `WATCH` define in case of watch mode (by [@Krzysztof-Cieslak](https://github.com/Krzysztof-Cieslak))
 
-## 0.11.0 - 02.03.2020
+## [0.13.0] - 2020-04-20
 ### Added
-* Add a port argument to the watch command  (by [@toburger](https://github.com/toburger))
-* Collect and propogate loader errors (by [@jbeeko](https://github.com/jbeeko))
-* Add MultipleFiles as possible generator output (by [@Krzysztof-Cieslak](https://github.com/Krzysztof-Cieslak))
+- Add way to check developments to the template (by [@robertpi](https://github.com/robertpi))
+- Summarize posts using more marker (by [@robertpi](https://github.com/robertpi))
+- Update to FCS 34.1 (by [@Krzysztof-Cieslak](https://github.com/Krzysztof-Cieslak))
 
-## 0.10.0 - 20.02.2020
+## [0.12.0] - 2020-04-14
 ### Added
-* Update to .NET Core 3.0
-* Adds tools manifest .config/dotnet-tools.json
-* Redesign Fornax around idea of `loaders` and `generators`
-* Create new `fornax new` template
+- WebSocket refresh uses excesive CPU (by [@robertpi](https://github.com/robertpi))
+- Allow generate to return a byte array (by [@robertpi](https://github.com/robertpi))
+- Refactor template (by [@robertpi](https://github.com/robertpi))
 
-## 0.2.0 - 05.08.2019
+## [0.11.1] - 2020-04-07
 ### Added
-* Update to .Net Core
-* Distribute as .Net Core global tool
+- Fix for once generator running even if not found (by [@sasmithjr](https://github.com/sasmithjr))
+- Use exceptions .ToString() when printing error (by [@robertpi](https://github.com/robertpi))
 
-## 0.1.0 - 04.06.2017
+## [0.11.0] - 2020-03-02
 ### Added
-* Defining templates in F# DSL
-* Creating pages using templates from `.md` files with `layout` entry
-* Creating plain pages without templates from `md` files without `layout` entry
-* Transforming `.less` files to `.css` files
-* Transforming `.scss` files to `.css` files (require having `sass` installed)
-* Coping other static content to output directory
+- Add a port argument to the watch command  (by [@toburger](https://github.com/toburger))
+- Collect and propogate loader errors (by [@jbeeko](https://github.com/jbeeko))
+- Add MultipleFiles as possible generator output (by [@Krzysztof-Cieslak](https://github.com/Krzysztof-Cieslak))
+
+## [0.10.0] - 2020-02-20
+### Added
+- Update to .NET Core 3.0
+- Adds tools manifest .config/dotnet-tools.json
+- Redesign Fornax around idea of `loaders` and `generators`
+- Create new `fornax new` template
+
+## [0.2.0] - 2019-08-05
+### Added
+- Update to .Net Core
+- Distribute as .Net Core global tool
+
+## [0.1.0] - 2017-06-04
+### Added
+- Defining templates in F# DSL
+- Creating pages using templates from `.md` files with `layout` entry
+- Creating plain pages without templates from `md` files without `layout` entry
+- Transforming `.less` files to `.css` files
+- Transforming `.scss` files to `.css` files (require having `sass` installed)
+- Coping other static content to output directory

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.25" />
     <PackageVersion Include="Expecto" Version="10.2.3" />
     <PackageVersion Include="FSharp.Quotations.Evaluator" Version="2.1.0" />
-    <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.1.8" />
+    <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.3.0" />
     <PackageVersion Include="LibGit2Sharp" Version="0.31.0" />
     <PackageVersion Include="MSBuild.StructuredLogger" Version="2.3.17" />
     <PackageVersion Include="Suave" Version="2.6.2" />


### PR DESCRIPTION
The new changelog parser seems to be more strict about the expected change log format, so I also had to change the dates from DD-MM-YYYY yo YYYY-MM-DD, add brackets around some versions, and fix some PR Links

I was seeing if updating fixed the issues with FParsec when building withing Visual Studio, e.g.

<img width="1396" height="291" alt="image" src="https://github.com/user-attachments/assets/62302667-7f73-4c35-b10d-faf86260bf79" />

but then the new parser got more errors from the changelog, e.g

<img width="1426" height="58" alt="image" src="https://github.com/user-attachments/assets/ae1407d6-262c-43f0-b4da-bbfae1db2151" />

So - had to make some changes for that as well.