### PR TITLE
Update FAKE to 6.1.4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,15 +9,15 @@
   <ItemGroup>
     <PackageVersion Include="FSharp.Core" Version="[8.0.100]" />
     <PackageVersion Include="FSharp.Compiler.Service" Version="[43.8.100]" />
-    <PackageVersion Include="Fake.Api.Github" Version="6.0.0" />
-    <PackageVersion Include="Fake.Core.Process" Version="6.0.0" />
-    <PackageVersion Include="Fake.Core.ReleaseNotes" Version="6.0.0" />
-    <PackageVersion Include="Fake.Core.UserInput" Version="6.0.0" />
-    <PackageVersion Include="Fake.Core.Target" Version="6.0.0" />
-    <PackageVersion Include="Fake.DotNet.Cli" Version="6.0.0" />
-    <PackageVersion Include="Fake.DotNet.MSBuild" Version="6.0.0" />
-    <PackageVersion Include="Fake.IO.FileSystem" Version="6.0.0" />
-    <PackageVersion Include="Fake.Tools.Git" Version="6.0.0" />
+    <PackageVersion Include="Fake.Api.Github" Version="6.1.4" />
+    <PackageVersion Include="Fake.Core.Process" Version="6.1.4" />
+    <PackageVersion Include="Fake.Core.ReleaseNotes" Version="6.1.4" />
+    <PackageVersion Include="Fake.Core.UserInput" Version="6.1.4" />
+    <PackageVersion Include="Fake.Core.Target" Version="6.1.4" />
+    <PackageVersion Include="Fake.DotNet.Cli" Version="6.1.4" />
+    <PackageVersion Include="Fake.DotNet.MSBuild" Version="6.1.4" />
+    <PackageVersion Include="Fake.IO.FileSystem" Version="6.1.4" />
+    <PackageVersion Include="Fake.Tools.Git" Version="6.1.4" />
     <PackageVersion Include="Argu" Version="6.2.5" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.25" />
     <PackageVersion Include="Expecto" Version="10.2.3" />

--- a/build.fsproj
+++ b/build.fsproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Fake.DotNet.MSBuild" />
     <PackageReference Include="Fake.IO.FileSystem" />
     <PackageReference Include="Fake.Tools.Git" />
-    <PackageReference Include="FSharp.Core" />
+    <PackageReference Include="FSharp.Core" VersionOverride="8.0.400" />
     <PackageReference Include="MSBuild.StructuredLogger" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
There are no functional changes here, but it does pick up several transitive dependency updates which fixes some CVE vulnernability warnings in the build.

There is one little issue with this in that Fornax is building with FSharp.Core 8.0.100 and the newer FAKE wants 8.0.400, but hopefully it's ok for the build script to use a newer version and the actual Fornax tool to continue with the existing version.